### PR TITLE
fix: remove the unused variable in NotifyClient in shared_module.

### DIFF
--- a/shared_lib/shared_module/notify_client.py
+++ b/shared_lib/shared_module/notify_client.py
@@ -9,7 +9,6 @@ from .gcloud import get_id_token
 class NotifyClient:
     token_id: str
     notify_api: str
-    notify_api_token: str
 
     def _get_api_token(self):
         return get_id_token(self.notify_api)


### PR DESCRIPTION
- Remove the unused variable `notify_api_token` in `NotifyClient` in `shared_module`.